### PR TITLE
Feature/transformer reform with ppo

### DIFF
--- a/deep/stable_baselines/dqn_transformer.py
+++ b/deep/stable_baselines/dqn_transformer.py
@@ -15,8 +15,8 @@ class DQNModelSettings(ModelSettings):
 train_envs = get_basic_train_settings(name="DQN")
 train_envs.update(
     {
-        "expname": "transformer-L3-H4-Emb128-lrdecay3e-4-CONT-high-reward",
-        "total_timesteps": int(40e5),
+        "expname": "transformer-L3-H4-Emb128-lrdecay3e-4",
+        "total_timesteps": int(20e5),
         "checkpoint_freq": int(10e4),
         "eval_freq": int(10e4),
         "n_envs": 4
@@ -75,4 +75,4 @@ model_envs: DQNModelSettings = {
 
 
 if __name__ == "__main__":
-    train(train_envs, model_envs, DQN, continue_from="./logs/checkpoints/DQN.transformer-L3-H4-Emb128-lrdecay3e-4-lockemb/rl_model_2000000_steps.zip")
+    train(train_envs, model_envs, DQN)

--- a/deep/stable_baselines/dqn_transformer.py
+++ b/deep/stable_baselines/dqn_transformer.py
@@ -15,7 +15,7 @@ class DQNModelSettings(ModelSettings):
 train_envs = get_basic_train_settings(name="DQN")
 train_envs.update(
     {
-        "expname": "transformer-L3-H8-Emb128-lrdecay3e-4",
+        "expname": "transformer-L1-H8-Emb128-lrdecay3e-4",
         "total_timesteps": int(20e5),
         "checkpoint_freq": int(10e4),
         "eval_freq": int(10e4),
@@ -56,8 +56,10 @@ model_envs: DQNModelSettings = {
         "tensorboard_log": "./logs/tb/",
         "verbose": 1,
         "policy_kwargs": {
-            "activation_fn": torch.nn.ReLU,
-            "net_arch": [128, 128],
+            "transformer_layers": 6,
+            "vector_size": 128,
+            "hidden_dimension": 128,
+            "transformer_heads": 8,
             "features_extractor_class":CustomCombinedExtractor,
             "features_extractor_kwargs": {
                 "prob_hidden_dim": 16,

--- a/deep/stable_baselines/dqn_transformer.py
+++ b/deep/stable_baselines/dqn_transformer.py
@@ -5,7 +5,7 @@ from stable_baselines3 import DQN
 from deep.stable_baselines.train import train
 from deep.stable_baselines.util import ModelSettings, get_basic_train_settings
 from deep.stable_baselines.policy.council_feature import CustomCombinedExtractor
-from deep.stable_baselines.policy.network import IndependentQPolicy
+from deep.stable_baselines.policy.transformer_network import TransformerQPolicy
 from stable_baselines3.her.her_replay_buffer import HerReplayBuffer
 
 class DQNModelSettings(ModelSettings):
@@ -45,7 +45,7 @@ class LearningRateDecay():
 
 
 model_envs: DQNModelSettings = {
-    "policy": IndependentQPolicy,
+    "policy": TransformerQPolicy,
     "learning_rate": LearningRateDecay(3e-4, 3e-5),
     "seed": 37,
     "kwargs": {
@@ -59,7 +59,12 @@ model_envs: DQNModelSettings = {
             "activation_fn": torch.nn.ReLU,
             "net_arch": [128, 128],
             "features_extractor_class":CustomCombinedExtractor,
-            "features_extractor_kwargs":dict(),
+            "features_extractor_kwargs": {
+                "prob_hidden_dim": 16,
+                "suggesion_feature_hidden_dim": 16,
+                "embedding_dim": 128,
+                "flatten_output": False
+            },
         },
         "tensorboard_log": "./logs/tb/",
         "verbose": 1,

--- a/deep/stable_baselines/dqn_transformer.py
+++ b/deep/stable_baselines/dqn_transformer.py
@@ -1,0 +1,71 @@
+from typing import Any
+import torch
+from stable_baselines3 import DQN
+
+from deep.stable_baselines.train import train
+from deep.stable_baselines.util import ModelSettings, get_basic_train_settings
+from deep.stable_baselines.policy.council_feature import CustomCombinedExtractor
+from deep.stable_baselines.policy.network import IndependentQPolicy
+from stable_baselines3.her.her_replay_buffer import HerReplayBuffer
+
+class DQNModelSettings(ModelSettings):
+    ...
+
+
+train_envs = get_basic_train_settings(name="DQN")
+train_envs.update(
+    {
+        "expname": "transformer-L3-H8-Emb128-lrdecay3e-4",
+        "total_timesteps": int(20e5),
+        "checkpoint_freq": int(10e4),
+        "eval_freq": int(10e4),
+        "n_envs": 4
+    }
+)
+
+
+class LearningRateDecay():
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+    def __repr__(self):
+        return f"LearningRateDecay:<{self.start}>-><{self.end}>"        
+
+    def __call__(self, progress: float) -> float:
+        rate = self.end / self.start
+        progress = 1 - progress
+
+        if progress < 0.2:
+            return self.start * (5 * progress)
+
+        progress = (progress - 0.2) * 1.25
+
+        return self.start * (rate ** progress)
+
+
+model_envs: DQNModelSettings = {
+    "policy": IndependentQPolicy,
+    "learning_rate": LearningRateDecay(3e-4, 3e-5),
+    "seed": 37,
+    "kwargs": {
+        "batch_size": 128,
+        "tau": 0.5,
+        "gamma": 0.99,
+        "train_freq": 4,
+        "tensorboard_log": "./logs/tb/",
+        "verbose": 1,
+        "policy_kwargs": {
+            "activation_fn": torch.nn.ReLU,
+            "net_arch": [128, 128],
+            "features_extractor_class":CustomCombinedExtractor,
+            "features_extractor_kwargs":dict(),
+        },
+        "tensorboard_log": "./logs/tb/",
+        "verbose": 1,
+    },
+}
+
+
+if __name__ == "__main__":
+    train(train_envs, model_envs, DQN) #, continue_from="./logs/checkpoints/DQN.transformer-L2-H4-Emb128-lrdecay3e-4/rl_model_1000000_steps.zip"

--- a/deep/stable_baselines/dqn_transformer.py
+++ b/deep/stable_baselines/dqn_transformer.py
@@ -15,8 +15,8 @@ class DQNModelSettings(ModelSettings):
 train_envs = get_basic_train_settings(name="DQN")
 train_envs.update(
     {
-        "expname": "transformer-L1-H8-Emb128-lrdecay3e-4",
-        "total_timesteps": int(20e5),
+        "expname": "transformer-L3-H4-Emb128-lrdecay3e-4-CONT-high-reward",
+        "total_timesteps": int(40e5),
         "checkpoint_freq": int(10e4),
         "eval_freq": int(10e4),
         "n_envs": 4
@@ -56,10 +56,10 @@ model_envs: DQNModelSettings = {
         "tensorboard_log": "./logs/tb/",
         "verbose": 1,
         "policy_kwargs": {
-            "transformer_layers": 6,
+            "transformer_layers": 3,
             "vector_size": 128,
             "hidden_dimension": 128,
-            "transformer_heads": 8,
+            "transformer_heads": 4,
             "features_extractor_class":CustomCombinedExtractor,
             "features_extractor_kwargs": {
                 "prob_hidden_dim": 16,
@@ -75,4 +75,4 @@ model_envs: DQNModelSettings = {
 
 
 if __name__ == "__main__":
-    train(train_envs, model_envs, DQN) #, continue_from="./logs/checkpoints/DQN.transformer-L2-H4-Emb128-lrdecay3e-4/rl_model_1000000_steps.zip"
+    train(train_envs, model_envs, DQN, continue_from="./logs/checkpoints/DQN.transformer-L3-H4-Emb128-lrdecay3e-4-lockemb/rl_model_2000000_steps.zip")

--- a/deep/stable_baselines/policy/network.py
+++ b/deep/stable_baselines/policy/network.py
@@ -1,0 +1,130 @@
+from typing import Any, Dict, List, Optional, Type
+
+import torch as th
+from gymnasium import spaces
+from torch import nn
+
+from stable_baselines3.common.policies import BasePolicy
+from stable_baselines3.common.torch_layers import (
+    BaseFeaturesExtractor,
+)
+from stable_baselines3.common.type_aliases import Schedule
+from stable_baselines3.dqn.policies import DQNPolicy
+
+
+class DiscreteAction(nn.Module):
+    def __init__(self, vector_size: int = 128, hidden_dimension: int = 64):
+        super(DiscreteAction, self).__init__()
+        self.nn = nn.Sequential(
+            nn.Linear(vector_size * (1 + 1 + 2), hidden_dimension),
+            nn.ReLU(),
+            nn.Linear(hidden_dimension, 1),
+        )
+        self.reroll = nn.Sequential(
+            nn.Linear(vector_size * 10, hidden_dimension),
+            nn.ReLU(),
+            nn.Linear(hidden_dimension, 1),
+        )
+
+    def forward(self, x):
+        boards = x[:, :5, :] # [B, 5, N]
+        councils = x[:, 5:8, :] # [B, 3, N]
+        ctxs = x[:, 8:, :] # [B, 2, N]
+
+        ctxs = th.flatten(ctxs, 1)
+        ctxs = th.stack([ctxs, ctxs, ctxs], dim=1)
+        ctxs = th.stack([ctxs, ctxs, ctxs, ctxs, ctxs], dim=1)
+
+        boards = th.stack(
+            [boards, boards, boards], dim=2
+        )
+        councils = th.stack(
+            [councils, councils, councils, councils, councils], dim=1
+        )
+
+        action_space_vector = th.cat([boards, councils], dim=-1)
+        action_space_vector = th.cat([action_space_vector, ctxs], dim=-1)
+        output = self.nn(action_space_vector)
+
+        output = th.flatten(th.squeeze(output, dim=1), start_dim=1)
+
+        # Reroll defining network
+        reroll = self.reroll(th.flatten(x, start_dim=1))
+        action = th.cat([output, reroll], dim=1)
+
+        return action
+
+
+class IndependentQNetwork(BasePolicy):
+    """
+    Action-Value (Q-Value) network for DQN
+
+    :param observation_space: Observation space
+    :param action_space: Action space
+    :param net_arch: The specification of the policy and value networks.
+    :param activation_fn: Activation function
+    :param normalize_images: Whether to normalize images or not,
+         dividing by 255.0 (True by default)
+    """
+
+    action_space: spaces.Discrete
+
+    def __init__(
+        self,
+        observation_space: spaces.Space,
+        action_space: spaces.Discrete,
+        features_extractor: BaseFeaturesExtractor,
+        features_dim: int,
+        net_arch: Optional[List[int]] = None,
+        activation_fn: Type[nn.Module] = nn.ReLU,
+        normalize_images: bool = True,
+    ) -> None:
+        super().__init__(
+            observation_space,
+            action_space,
+            features_extractor=features_extractor,
+            normalize_images=normalize_images,
+        )
+
+        if net_arch is None:
+            net_arch = [64, 64]
+
+        self.net_arch = net_arch
+        self.activation_fn = activation_fn
+        self.features_dim = features_dim
+        self.q_net = DiscreteAction()
+
+    def forward(self, obs: th.Tensor) -> th.Tensor:
+        """
+        Predict the q-values.
+
+        :param obs: Observation
+        :return: The estimated Q-Value for each action.
+        """
+        return self.q_net(self.extract_features(obs, self.features_extractor))
+
+    def _predict(self, observation: th.Tensor, deterministic: bool = True) -> th.Tensor:
+        q_values = self(observation)
+        # Greedy action
+        action = q_values.argmax(dim=1).reshape(-1)
+        return action
+
+    def _get_constructor_parameters(self) -> Dict[str, Any]:
+        data = super()._get_constructor_parameters()
+
+        data.update(
+            dict(
+                net_arch=self.net_arch,
+                features_dim=self.features_dim,
+                activation_fn=self.activation_fn,
+                features_extractor=self.features_extractor,
+            )
+        )
+        return data
+
+
+class IndependentQPolicy(DQNPolicy):
+    def make_q_net(self) -> IndependentQNetwork:
+        # Make sure we always have separate networks for features extractors etc
+        net_args = self._update_features_extractor(self.net_args, features_extractor=None)
+        return IndependentQNetwork(**net_args).to(self.device)

--- a/deep/stable_baselines/policy/ppo_transformer_network.py
+++ b/deep/stable_baselines/policy/ppo_transformer_network.py
@@ -15,7 +15,7 @@ from stable_baselines3.common.torch_layers import (
     FlattenExtractor,
     MlpExtractor,
 )
-from deep.stable_baselines.policy.transformer_network import TransformerDecisionNet
+from deep.stable_baselines.policy.transformer_network import DecisionNet, TransformerDecisionNet
 
 
 class PPOTransformerPolicy(ActorCriticPolicy):
@@ -100,10 +100,11 @@ class PPOTransformerPolicy(ActorCriticPolicy):
         )
         self.action_net = self._make_action_net()
         self.value_net = nn.Sequential(
-            nn.Linear(
-                self.mlp_extractor.latent_dim_vf, 64
-            ),
             nn.Flatten(start_dim=1),
+            nn.Linear(
+                1280, 64
+            ),
+            nn.ReLU(),
             nn.Linear(
                 64, 1
             )

--- a/deep/stable_baselines/policy/ppo_transformer_network.py
+++ b/deep/stable_baselines/policy/ppo_transformer_network.py
@@ -1,0 +1,113 @@
+from typing import Any, Dict, List, Optional, Type
+
+import torch as th
+from gymnasium import spaces
+from torch import nn
+
+from stable_baselines3.common.policies import ActorCriticPolicy
+from stable_baselines3.common.torch_layers import (
+    BaseFeaturesExtractor,
+    FlattenExtractor,
+)
+from stable_baselines3.common.type_aliases import Schedule
+from stable_baselines3.common.torch_layers import (
+    BaseFeaturesExtractor,
+    FlattenExtractor,
+    MlpExtractor,
+)
+from deep.stable_baselines.policy.transformer_network import TransformerDecisionNet
+
+
+class PPOTransformerPolicy(ActorCriticPolicy):
+    def __init__(
+        self,
+        observation_space: spaces.Space,
+        action_space: spaces.Discrete,
+        lr_schedule: Schedule,
+        use_sde: bool = False,
+        features_extractor_class: Type[BaseFeaturesExtractor] = FlattenExtractor,
+        features_extractor_kwargs: Optional[Dict[str, Any]] = None,
+        normalize_images: bool = True,
+        optimizer_class: Type[th.optim.Optimizer] = th.optim.Adam,
+        optimizer_kwargs: Optional[Dict[str, Any]] = None,
+        vector_size: int = 128, 
+        hidden_dimension: int = 64,
+        transformer_layers: int = 3,
+        transformer_heads: int = 8,
+    ) -> None:
+        self.net_args = {
+            "observation_space": observation_space,
+            "action_space": action_space,
+            "vector_size": vector_size,
+            "hidden_dimension": hidden_dimension,
+            "transformer_layers": transformer_layers,
+            "transformer_heads": transformer_heads,
+            "normalize_images": normalize_images,
+        }
+
+        self.vector_size = vector_size
+        self.hidden_dimension = hidden_dimension
+        self.transformer_layers = transformer_layers
+        self.transformer_heads = transformer_heads
+
+        super().__init__(
+            observation_space,
+            action_space,
+            lr_schedule,
+            features_extractor_class=features_extractor_class,
+            features_extractor_kwargs=features_extractor_kwargs,
+            optimizer_class=optimizer_class,
+            optimizer_kwargs=optimizer_kwargs,
+            normalize_images=normalize_images,
+        )
+
+    def _get_constructor_parameters(self) -> Dict[str, Any]:
+        data = super()._get_constructor_parameters()
+
+        data.update(
+            dict(
+                vector_size=self.net_args["vector_size"],
+                hidden_dimension=self.net_args["hidden_dimension"],
+                transformer_layers=self.net_args["transformer_layers"],
+                transformer_heads=self.net_args["transformer_heads"],
+                lr_schedule=self._dummy_schedule,  # dummy lr schedule, not needed for loading policy alone
+                optimizer_class=self.optimizer_class,
+                optimizer_kwargs=self.optimizer_kwargs,
+                features_extractor_class=self.features_extractor_class,
+                features_extractor_kwargs=self.features_extractor_kwargs,
+            )
+        )
+        return data
+
+    def _make_action_net(self) -> TransformerDecisionNet:
+        # Make sure we always have separate networks for features extractors etc
+        net_args = self._update_features_extractor(self.net_args, features_extractor=None)
+        net_args.pop("features_dim")
+        return TransformerDecisionNet(**net_args).to(self.device)
+
+    def _build(self, lr_schedule: Schedule) -> None:
+        """
+        Create the networks and the optimizer.
+
+        :param lr_schedule: Learning rate schedule
+            lr_schedule(1) is the initial learning rate
+        """
+        self.mlp_extractor = MlpExtractor(
+            self.features_dim,
+            net_arch=[],
+            activation_fn=self.activation_fn,
+            device=self.device,
+        )
+        self.action_net = self._make_action_net()
+        self.value_net = nn.Sequential(
+            nn.Linear(
+                self.mlp_extractor.latent_dim_vf, 64
+            ),
+            nn.Flatten(start_dim=1),
+            nn.Linear(
+                64, 1
+            )
+        )
+
+        # Setup optimizer with initial learning rate
+        self.optimizer = self.optimizer_class(self.parameters(), lr=lr_schedule(1), **self.optimizer_kwargs)

--- a/deep/stable_baselines/policy/transformer_network.py
+++ b/deep/stable_baselines/policy/transformer_network.py
@@ -85,6 +85,7 @@ class TransformerDecisionNet(nn.Module):
             hidden_dimension: int = 64,
             transformer_layers: int = 3,
             transformer_heads: int = 8,
+            **kwargs,
         ):
 
         super(TransformerDecisionNet, self).__init__()

--- a/deep/stable_baselines/policy/transformer_network.py
+++ b/deep/stable_baselines/policy/transformer_network.py
@@ -97,7 +97,7 @@ class TransformerDecisionNet(nn.Module):
             [nn.TransformerEncoderLayer(
                 vector_size,
                 self._transformer_heads,
-                dim_feedforward=vector_size * 2,
+                dim_feedforward=vector_size * 4,
                 batch_first=True
             ) for _ in range(self._transformer_layers)]
         ) 

--- a/deep/stable_baselines/policy/transformer_network.py
+++ b/deep/stable_baselines/policy/transformer_network.py
@@ -7,6 +7,7 @@ from torch import nn
 from stable_baselines3.common.policies import BasePolicy
 from stable_baselines3.common.torch_layers import (
     BaseFeaturesExtractor,
+    FlattenExtractor,
 )
 from stable_baselines3.common.type_aliases import Schedule
 from stable_baselines3.dqn.policies import DQNPolicy
@@ -110,8 +111,6 @@ class TransformerQNetwork(BasePolicy):
 
     :param observation_space: Observation space
     :param action_space: Action space
-    :param net_arch: The specification of the policy and value networks.
-    :param activation_fn: Activation function
     :param normalize_images: Whether to normalize images or not,
          dividing by 255.0 (True by default)
     """
@@ -135,7 +134,6 @@ class TransformerQNetwork(BasePolicy):
             features_extractor=features_extractor,
             normalize_images=normalize_images,
         )
-
 
         self.vector_size = vector_size
         self.hidden_dimension = hidden_dimension
@@ -163,9 +161,128 @@ class TransformerQNetwork(BasePolicy):
         )
         return data
 
+    def forward(self, obs: th.Tensor) -> th.Tensor:
+        """
+        Predict the q-values.
 
-class TransformerQPolicy(DQNPolicy):
+        :param obs: Observation
+        :return: The estimated Q-Value for each action.
+        """
+        return self.q_net(self.extract_features(obs, self.features_extractor))
+
+    def _predict(self, observation: th.Tensor, deterministic: bool = True) -> th.Tensor:
+        q_values = self(observation)
+        # Greedy action
+        action = q_values.argmax(dim=1).reshape(-1)
+        return action
+
+
+class TransformerQPolicy(BasePolicy):
+
+    q_net: TransformerQNetwork
+    q_net_target: TransformerQNetwork
+
+    def __init__(
+        self,
+        observation_space: spaces.Space,
+        action_space: spaces.Discrete,
+        lr_schedule: Schedule,
+        features_extractor_class: Type[BaseFeaturesExtractor] = FlattenExtractor,
+        features_extractor_kwargs: Optional[Dict[str, Any]] = None,
+        normalize_images: bool = True,
+        optimizer_class: Type[th.optim.Optimizer] = th.optim.Adam,
+        optimizer_kwargs: Optional[Dict[str, Any]] = None,
+        vector_size: int = 128, 
+        hidden_dimension: int = 64,
+        transformer_layers: int = 3,
+        transformer_heads: int = 8,
+    ) -> None:
+        super().__init__(
+            observation_space,
+            action_space,
+            features_extractor_class,
+            features_extractor_kwargs,
+            optimizer_class=optimizer_class,
+            optimizer_kwargs=optimizer_kwargs,
+            normalize_images=normalize_images,
+        )
+
+        self.vector_size = vector_size
+        self.hidden_dimension = hidden_dimension
+        self.transformer_layers = transformer_layers
+        self.transformer_heads = transformer_heads
+
+        self.net_args = {
+            "observation_space": self.observation_space,
+            "action_space": self.action_space,
+            "vector_size": vector_size,
+            "hidden_dimension": hidden_dimension,
+            "transformer_layers": transformer_layers,
+            "transformer_heads": transformer_heads,
+            "normalize_images": normalize_images,
+        }
+
+        self._build(lr_schedule)
+
+    def _build(self, lr_schedule: Schedule) -> None:
+        """
+        Create the network and the optimizer.
+
+        Put the target network into evaluation mode.
+
+        :param lr_schedule: Learning rate schedule
+            lr_schedule(1) is the initial learning rate
+        """
+
+        self.q_net = self.make_q_net()
+        self.q_net_target = self.make_q_net()
+        self.q_net_target.load_state_dict(self.q_net.state_dict())
+        self.q_net_target.set_training_mode(False)
+
+        # Setup optimizer with initial learning rate
+        self.optimizer = self.optimizer_class(  # type: ignore[call-arg]
+            self.parameters(),
+            lr=lr_schedule(1),
+            **self.optimizer_kwargs,
+        )
+
     def make_q_net(self) -> TransformerQNetwork:
         # Make sure we always have separate networks for features extractors etc
         net_args = self._update_features_extractor(self.net_args, features_extractor=None)
+        net_args.pop("features_dim")
         return TransformerQNetwork(**net_args).to(self.device)
+
+    def forward(self, obs: th.Tensor, deterministic: bool = True) -> th.Tensor:
+        return self._predict(obs, deterministic=deterministic)
+
+    def _predict(self, obs: th.Tensor, deterministic: bool = True) -> th.Tensor:
+        return self.q_net._predict(obs, deterministic=deterministic)
+
+    def _get_constructor_parameters(self) -> Dict[str, Any]:
+        data = super()._get_constructor_parameters()
+
+        data.update(
+            dict(
+                vector_size=self.net_args["vector_size"],
+                hidden_dimension=self.net_args["hidden_dimension"],
+                transformer_layers=self.net_args["transformer_layers"],
+                transformer_heads=self.net_args["transformer_heads"],
+                lr_schedule=self._dummy_schedule,  # dummy lr schedule, not needed for loading policy alone
+                optimizer_class=self.optimizer_class,
+                optimizer_kwargs=self.optimizer_kwargs,
+                features_extractor_class=self.features_extractor_class,
+                features_extractor_kwargs=self.features_extractor_kwargs,
+            )
+        )
+        return data
+
+    def set_training_mode(self, mode: bool) -> None:
+        """
+        Put the policy in either training or evaluation mode.
+
+        This affects certain modules, such as batch normalisation and dropout.
+
+        :param mode: if true, set to training mode, else set to evaluation mode
+        """
+        self.q_net.set_training_mode(mode)
+        self.training = mode

--- a/deep/stable_baselines/ppo_transformer.py
+++ b/deep/stable_baselines/ppo_transformer.py
@@ -2,7 +2,7 @@ from stable_baselines3 import PPO
 
 from deep.stable_baselines.train import train
 from deep.stable_baselines.util import ModelSettings, get_basic_train_settings
-from deep.stable_baselines.policy.council_feature import CustomCombinedExtractor
+from deep.stable_baselines.policy.council_feature import CustomCombinedExtractor ,CombinedTransformerExtractor
 from deep.stable_baselines.policy.ppo_transformer_network import PPOTransformerPolicy
 
 
@@ -13,7 +13,7 @@ class PPOModelSettings(ModelSettings):
 train_envs = get_basic_train_settings(name="PPO")
 train_envs.update(
     {
-        "expname": "transformer-L3-H4-Emb128-lrdecay1e-3",
+        "expname": "transformer-L3-H4-Emb128-1e-4-disentangle-obs-mid-12",
         "total_timesteps": int(40e5),
         "checkpoint_freq": int(10e4),
         "eval_freq": int(10e4),
@@ -44,7 +44,7 @@ class LearningRateDecay():
 
 model_envs: PPOModelSettings = {
     "policy": PPOTransformerPolicy,
-    "learning_rate": LearningRateDecay(1e-3, 1e-4),
+    "learning_rate": 1e-4,
     "seed": 37,
     "kwargs": {
         "batch_size": 32,

--- a/deep/stable_baselines/ppo_transformer.py
+++ b/deep/stable_baselines/ppo_transformer.py
@@ -1,0 +1,74 @@
+from stable_baselines3 import PPO
+
+from deep.stable_baselines.train import train
+from deep.stable_baselines.util import ModelSettings, get_basic_train_settings
+from deep.stable_baselines.policy.council_feature import CustomCombinedExtractor
+from deep.stable_baselines.policy.ppo_transformer_network import PPOTransformerPolicy
+
+
+class PPOModelSettings(ModelSettings):
+    ...
+
+
+train_envs = get_basic_train_settings(name="PPO")
+train_envs.update(
+    {
+        "expname": "transformer-L3-H4-Emb128-lrdecay1e-3",
+        "total_timesteps": int(40e5),
+        "checkpoint_freq": int(10e4),
+        "eval_freq": int(10e4),
+        "n_envs": 4
+    }
+)
+
+
+class LearningRateDecay():
+    def __init__(self, start, end):
+        self.start = start
+        self.end = end
+
+    def __repr__(self):
+        return f"LearningRateDecay:<{self.start}>-><{self.end}>"        
+
+    def __call__(self, progress: float) -> float:
+        rate = self.end / self.start
+        progress = 1 - progress
+
+        if progress < 0.2:
+            return self.start * (5 * progress)
+
+        progress = (progress - 0.2) * 1.25
+
+        return self.start * (rate ** progress)
+
+
+model_envs: PPOModelSettings = {
+    "policy": PPOTransformerPolicy,
+    "learning_rate": LearningRateDecay(1e-3, 1e-4),
+    "seed": 37,
+    "kwargs": {
+        "batch_size": 32,
+        "gamma": 0.99,
+        "tensorboard_log": "./logs/tb/",
+        "verbose": 1,
+        "policy_kwargs": {
+            "transformer_layers": 3,
+            "vector_size": 128,
+            "hidden_dimension": 128,
+            "transformer_heads": 4,
+            "features_extractor_class": CustomCombinedExtractor,
+            "features_extractor_kwargs": {
+                "prob_hidden_dim": 16,
+                "suggesion_feature_hidden_dim": 16,
+                "embedding_dim": 128,
+                "flatten_output": False,
+            },
+        },
+        "tensorboard_log": "./logs/tb/",
+        "verbose": 1,
+    },
+}
+
+
+if __name__ == "__main__":
+    train(train_envs, model_envs, PPO)

--- a/deep/stable_baselines/train.py
+++ b/deep/stable_baselines/train.py
@@ -111,7 +111,7 @@ def _serialize_config(nested_dict):
 
 
 def train(
-    train_envs: TrainSettings, model_envs: ModelSettings, Model: Type[BaseAlgorithm]
+    train_envs: TrainSettings, model_envs: ModelSettings, Model: Type[BaseAlgorithm], continue_from: str = "",
 ) -> None:
     n_envs = train_envs["n_envs"]
     # Env Control
@@ -141,11 +141,16 @@ def train(
     print("model envs:")
     print(*(model_envs["kwargs"].items()), sep="\n")
 
-    # Create Model
-    model = Model(
-        model_envs["policy"], env, model_envs["learning_rate"], seed=model_envs["seed"], **model_envs["kwargs"]
-    )
-    model.set_random_seed(model_envs["seed"])
+    if continue_from:
+        model = Model.load(continue_from)
+        model.set_env(env)
+    else:
+        # Create Model
+        model = Model(
+            model_envs["policy"], env, model_envs["learning_rate"], seed=model_envs["seed"], **model_envs["kwargs"]
+        )
+        model.set_random_seed(model_envs["seed"])
+
     checkpoint_callback = get_callback(
         train_envs["checkpoint_freq"] // n_envs, train_envs["eval_freq"] // n_envs, f"./logs/checkpoints/{train_envs['name']}.{train_envs['expname']}"
     )

--- a/deep/stable_baselines/train.py
+++ b/deep/stable_baselines/train.py
@@ -116,7 +116,7 @@ def train(
     n_envs = train_envs["n_envs"]
     # Env Control
     register_env()
-    env = make_vec_env(f"pylixir/{ENV_NAME}-v0", env_kwargs={"render_mode": "human"}, n_envs=n_envs)
+    env = make_vec_env(f"pylixir/{ENV_NAME}-v0", env_kwargs={"render_mode": "human"}, n_envs=n_envs, seed=0)
     # env = PylixirEnv()
     # env.reset(0)
     action_dim = env.action_space.n

--- a/pylixir/core/base.py
+++ b/pylixir/core/base.py
@@ -42,6 +42,9 @@ class Randomness(metaclass=abc.ABCMeta):
             valid_indices = [
                 idx for idx in range(len(basis)) if result[idx] < max_count
             ]
+            if len(valid_indices) == 0:
+                return result
+
             target_index = self.pick(valid_indices)
             result[target_index] += 1
 


### PR DESCRIPTION
- `deep/stable_baselines/dqn_transformer.py` : Transformer 구조를 사용하는 train script를 추가합니다.
- `deep/stable_baselines/policy/council_feature.py`: 내부에 미리 정의된 값을 제어할 수 있도록 생성자로 옮깁니다.
  - `CombinedTransformerExtractor` 를 추가하여, FeatureExtractor단계에서 Transformer를 적용할 수 있도록 합니다.
- `deep/stable_baselines/policy/ppo_transformer_network.py`, `deep/stable_baselines/ppo_transformer.py` : PPO를 transformer 구조로 적용합니다.
- `pylixir/core/base.py` : fix bug
- `deep/stable_baselines/policy/transformer_network.py`: Transformer Policy를 추가합니다.
- `deep/stable_baselines/train.py` : continue training을 구현합니다. default seed 0을 추가합니다.